### PR TITLE
fix: development shell user permissions (v1.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to yoctoctl will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2025-06-04
+
+### Fixed
+- Development shell now correctly uses `pokyuser` context for proper workspace permissions
+- Resolved permission denied errors when creating directories in `/workdir`
+
+### Technical Details
+- Added `--user pokyuser` flag to docker exec command in `cmd_shell()` function
+- Ensures consistent UID 1000 permissions matching workspace volume ownership
+- Fixes user context mismatch between direct docker run and yoctoctl shell access
+
 ## [1.0.0] - 2025-06-03
 
 ### Added
@@ -36,4 +47,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `version` - Display version information
 - `help` - Show command reference
 
+[1.0.1]: https://github.com/anaskalt/yoctoctl/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/anaskalt/yoctoctl/releases/tag/v1.0.0

--- a/yoctoctl
+++ b/yoctoctl
@@ -527,7 +527,7 @@ cmd_shell() {
 
     sleep 2
     
-    docker exec -it "$BUILDER_CONTAINER" bash -c '
+    docker exec -it --user pokyuser "$BUILDER_CONTAINER" bash -c '
         export PS1="\[\e[38;5;245m\][\[\e[38;5;67m\]poky\[\e[38;5;245m\]]\[\e[0m\] \[\e[38;5;109m\]\w\[\e[0m\] \[\e[38;5;245m\]>\[\e[0m\] "
         export HISTSIZE=10000
         export HISTFILESIZE=20000


### PR DESCRIPTION
Fixes permission issues in the development shell by ensuring correct user context.

## Problem
- Shell accessed via yoctoctl used incorrect user (usersetup)
- Permission denied errors when creating directories in /workdir
- Mismatch with direct docker run behavior

## Solution
- Added --user pokyuser flag to docker exec command
- Ensures UID 1000 context matching workspace volume ownership

## Testing
- [x] Verified user context: `whoami` returns pokyuser
- [x] Directory creation successful: `mkdir /workdir/test`
- [x] File permissions correct: `touch /workdir/test.txt`

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] CHANGELOG.md updated
- [x] Version remains backward compatible